### PR TITLE
replaces hard coded file separator by a system property to support Unix.

### DIFF
--- a/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/BaseMojo.java
+++ b/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/BaseMojo.java
@@ -72,7 +72,7 @@ public abstract class BaseMojo extends AbstractMojo {
 	}
 	
 	protected final String getModulePath() {
-		return new File(System.getProperty("java.home"), "jmods").getAbsolutePath() + ";" + getRelativePath(modulePath);
+		return new File(System.getProperty("java.home"), "jmods").getAbsolutePath() + System.getProperty("path.separator")  + getRelativePath(modulePath);
 	}
 	
 	protected final String getRelativePath(File file) {


### PR DESCRIPTION
Thank a lot for this plugin. 
On Unix system the file separator is : and not ;
Here is a simple proposal to use a system property for a better portability.