### PR TITLE
add a jlinkOptions to pass options directly to jlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The **link mojo** can be configured as follows:
                 <!-- type = boolean -->
                 <output>${project.build.directory}/image</output>
                 <!-- type = file, default = ${project.build.directory}/image -->
+                <jlinkOptions>--no-header-files,--no-man-pages,--strip-debug,--bind-services</jlinkOptions>
+                <!-- type = string, default = "" -->
             </configuration>
         </execution>
     </executions>

--- a/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/LinkMojo.java
+++ b/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/LinkMojo.java
@@ -88,7 +88,9 @@ public class LinkMojo extends BaseMojo {
 				params.add("--ignore-signing-information");
 			}
 
-			Stream.of(jlinkOptions.split(",")).forEach(params::add);
+			if (jlinkOptions != null) {
+				Stream.of(jlinkOptions.split(",")).forEach(params::add);
+			}
 
 			// Run tool (JLINK)
 

--- a/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/LinkMojo.java
+++ b/src/main/java/io/github/ghackenberg/maven/plugins/jigsaw/LinkMojo.java
@@ -25,6 +25,7 @@ package io.github.ghackenberg.maven.plugins.jigsaw;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -47,6 +48,9 @@ public class LinkMojo extends BaseMojo {
 
 	@Parameter(defaultValue = "${project.build.directory}/image")
 	private File output;
+
+	@Parameter(defaultValue = "")
+	private String jlinkOptions;
 
 	@Parameter
 	private String launcher;
@@ -83,6 +87,8 @@ public class LinkMojo extends BaseMojo {
 			if (ignoreSigningInformation) {
 				params.add("--ignore-signing-information");
 			}
+
+			Stream.of(jlinkOptions.split(",")).forEach(params::add);
 
 			// Run tool (JLINK)
 


### PR DESCRIPTION
Here is a proposal to pass options directly to jlink to support missing (and future) options for instance --no-header-files,--no-man-pages,--strip-debug,--compress=2